### PR TITLE
Tests for pinned upgrade-packages with upgrade also used

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -451,9 +451,8 @@ def cli(
         key_from_ireq(ireq) for ireq in constraints if not ireq.constraint
     }
 
-    allowed_upgrades = primary_packages | existing_pins_to_upgrade
     constraints.extend(
-        ireq for key, ireq in upgrade_install_reqs.items() if key in allowed_upgrades
+        ireq for key, ireq in upgrade_install_reqs.items() if key in primary_packages
     )
 
     constraints = [req for req in constraints if req.match_markers(extras)]

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -423,6 +423,25 @@ def cli(
                 )
             )
 
+    if upgrade_packages:
+        constraints_file = tempfile.NamedTemporaryFile(mode="wt")
+        constraints_file.write("\n".join(upgrade_packages))
+        constraints_file.flush()
+        reqs = list(
+            parse_requirements(
+                constraints_file.name,
+                finder=repository.finder,
+                session=repository.session,
+                options=repository.options,
+                constraint=True,
+            )
+        )
+        constraints_file.close()
+        for req in reqs:
+            req.comes_from = None
+            # req.comes_from = f"--upgrade-package {req.name}{req.specifier}"
+        constraints.extend(reqs)
+
     extras = tuple(itertools.chain.from_iterable(ex.split(",") for ex in extras))
 
     if extras and not setup_file_found:

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -424,7 +424,7 @@ def cli(
             )
 
     if upgrade_packages:
-        constraints_file = tempfile.NamedTemporaryFile(mode="wt")
+        constraints_file = tempfile.NamedTemporaryFile(mode="wt", delete=False)
         constraints_file.write("\n".join(upgrade_packages))
         constraints_file.flush()
         reqs = list(
@@ -436,7 +436,6 @@ def cli(
                 constraint=True,
             )
         )
-        constraints_file.close()
         for req in reqs:
             req.comes_from = None
             # req.comes_from = f"--upgrade-package {req.name}{req.specifier}"

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -798,6 +798,60 @@ def test_upgrade_packages_version_option_and_upgrade_no_existing_file(pip_conf, 
     assert "small-fake-b==0.1" in out.stderr
 
 
+@pytest.mark.network
+def test_upgrade_packages_version_option_and_upgrade_no_in_file(runner):
+    """
+    piptools respects --upgrade-package/-P inline list with specified versions
+    whilst also doing --upgrade, and the package to upgrade (pin) is not in the
+    requirements.in file, but in setup.py.
+    """
+    with open("setup.py", "w") as package:
+        package.write(
+            dedent(
+                """\
+                from setuptools import setup
+                setup(install_requires=["small-fake-a", "small-fake-b"])
+                """
+            )
+        )
+    with open("requirements.txt", "w") as req_in:
+        req_in.write("small-fake-a==0.1\nsmall-fake-b==0.1")
+    out = runner.invoke(
+        cli, ["--upgrade", "-P", "small-fake-b==0.1", "-f", MINIMAL_WHEELS_PATH]
+    )
+
+    assert out.exit_code == 0
+    assert "small-fake-a==0.2" in out.stderr
+    assert "small-fake-b==0.1" in out.stderr
+
+
+@pytest.mark.network
+def test_upgrade_packages_version_option_and_upgrade_no_in_file_no_existing_file(
+    runner,
+):
+    """
+    piptools respects --upgrade-package/-P inline list with specified versions
+    whilst also doing --upgrade and the package to upgrade (pin) is not in the
+    requirements.in file, but in setup.py and the output file does not exist.
+    """
+    with open("setup.py", "w") as package:
+        package.write(
+            dedent(
+                """\
+                from setuptools import setup
+                setup(install_requires=["small-fake-a", "small-fake-b"])
+                """
+            )
+        )
+    out = runner.invoke(
+        cli, ["--upgrade", "-P", "small-fake-b==0.1", "-f", MINIMAL_WHEELS_PATH]
+    )
+
+    assert out.exit_code == 0
+    assert "small-fake-a==0.2" in out.stderr
+    assert "small-fake-b==0.1" in out.stderr
+
+
 def test_quiet_option(runner):
     with open("requirements", "w"):
         pass


### PR DESCRIPTION
Added some tests to cover the tempfile changes introduced to support the combined `--upgrade` and `--upgrade-packages` arguments.

Tests added to cover the combined use of `--upgrade` and `--upgrade-packages` with a pinned version

##### Contributor checklist

- [X] Provided the tests for the changes
- [X] Requested (or received) a review from another contributor
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
